### PR TITLE
CI: Update versions used of community GitHub Actions

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 1.0.0
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
@@ -45,7 +45,7 @@ jobs:
         env:
           TF_WORKSPACE: ${{ matrix.workspace }}
 
-      - uses: actions/github-script@0.9.0
+      - uses: actions/github-script@v6
         if: github.event_name == 'pull_request'
         env:
           PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -63,8 +63,8 @@ jobs:
             </details>
 
             #### Author ✍️@${{ github.actor }}`;
-              
-            github.issues.createComment({
+
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
DEV-1359

Syncing the versions of community actions used to the latest major version.

This should avoid deprecation warnings seen in GitHub Actions.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
