### PR TITLE
Update actions to org-wide pins

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
           terraform_version: 1.4.5
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}


### PR DESCRIPTION
Updates GH actions to versions required by the organisation-wide whitelist: https://github.com/stackhpc/github-actions-list/blob/main/stackhpc.pinned.txt